### PR TITLE
Make marathon callback configurable and fix force redirect

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -19,10 +19,14 @@ defmodule Heimdall.Application do
 
     register_marathon = Application.fetch_env!(:heimdall, :register_marathon)
 
+    {:ok, hostname} = :inet.gethostname
+    default_callback = "http://#{hostname}:#{port}"
+    callback_url = Application.get_env(:heimdall, :marathon_callback_url, default_callback)
+
     register_worker = if register_marathon do
       [worker(
         Task,
-        [Heimdall.Marathon.RegisterCallback, :register, [marathon_url, port]],
+        [Heimdall.Marathon.RegisterCallback, :register, [marathon_url, callback_url]],
         restart: :temporary)]
     else
       []

--- a/lib/marathon/register_callback.ex
+++ b/lib/marathon/register_callback.ex
@@ -32,17 +32,15 @@ defmodule Heimdall.Marathon.RegisterCallback do
   @docs """
   Sends a post request to Marathon's event subscriptions with the
   location Heimdall is running and the path specified as `/marathon-callback`.
+  This location is specified by `:marathon_callback_url` when the app starts
 
   If the application is configured with :require_marathon set to true, this
-  function will raise an error. Otherwise it will just return the error like 
+  function will raise an error. Otherwise it will just return the error like
   `{:error, reason}`.
   """
-  def register(marathon_url, callback_port) do
-    {:ok, hostname} = :inet.gethostname
-    callback_url = "http://#{hostname}:#{callback_port}/marathon-callback"
+  def register(marathon_url, callback_url) do
     subscribe_url =
-      marathon_url <> "/v2/eventSubscriptions?callbackUrl=#{callback_url}"
-
+      marathon_url <> "/v2/eventSubscriptions?callbackUrl=#{callback_url}/marathon-callback"
     subscribe_to_marathon(subscribe_url)
   end
 end

--- a/lib/plug/forward_request.ex
+++ b/lib/plug/forward_request.ex
@@ -2,10 +2,10 @@ defmodule Heimdall.Plug.ForwardRequest do
 
   @moduledoc """
   This plug acts as a reverse proxy, it will forward any
-  request to a configured location. 
-  
-  This location can be configured either as a default 
-  location by setting the applications `:default_forward_url`, 
+  request to a configured location.
+
+  This location can be configured either as a default
+  location by setting the applications `:default_forward_url`,
   or by providing it in opts to `call/2` like `call(conn, forward_url: url)`
   """
 
@@ -40,7 +40,7 @@ defmodule Heimdall.Plug.ForwardRequest do
     new_url = build_url(forward_url, conn)
     forward_request
     |> Map.put(:url, new_url)
-    |> request(follow_redirect: true)
+    |> request(follow_redirect: true, force_redirect: true)
     |> response
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Heimdall.Mixfile do
   def project do
     [
       app: :heimdall,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Heimdall.Mixfile do
   def project do
     [
       app: :heimdall,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Emacs also striped trailing spaces for some reason?