### PR TITLE
Add new path features

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :heimdall, 
   marathon_url: "http://localhost:8080",
   default_forward_url: "http://localhost/",
-  register_marathon: true,
+  register_marathon: false,
   port: 4000

--- a/lib/dynamic_routes.ex
+++ b/lib/dynamic_routes.ex
@@ -28,22 +28,22 @@ defmodule Heimdall.DynamicRoutes do
     register(tab, host, path, plugs, opts)
   end
 
-  def register(tab, {_, _, _, _, _} = route) do
+  def register(tab, {_, _, _, _, _, _} = route) do
     true = :ets.insert(tab, route)
   end
 
   @doc """
   Registers a route for later lookup
   """
-  def register(tab, host, path, plugs, opts, strip_path \\ true) do
-    register(tab, {host, path, plugs, opts, strip_path})
+  def register(tab, host, path, plugs, opts, strip_path \\ true, proxy_path \\ []) do
+    register(tab, {host, path, plugs, opts, strip_path, proxy_path})
   end
 
   @doc """
   Unregisters a route given its host and path
   """
   def unregister(tab, host, path) do
-    true = :ets.match_delete(tab, {host, path, :_, :_, :_})
+    true = :ets.match_delete(tab, {host, path, :_, :_, :_, :_})
   end
 
   @doc """
@@ -65,17 +65,17 @@ defmodule Heimdall.DynamicRoutes do
       iex> Heimdall.DynamicRoutes.register(:some_table, "localhost", ["test", "path"], [], [])
       true
       iex> Heimdall.DynamicRoutes.lookup_path(:some_table, "localhost", ["test", "path"])
-      {"localhost", ["test", "path"], [], [], true}
+      {"localhost", ["test", "path"], [], [], true, []}
 
       iex> Heimdall.DynamicRoutes.register(:some_table, "localhost", ["test", "path"], [], [])
       true
       iex> Heimdall.DynamicRoutes.lookup_path(:some_table, "localhost", ["test", "path", "but", "longer"])
-      {"localhost", ["test", "path"], [], [], true}
+      {"localhost", ["test", "path"], [], [], true, []}
   """
   def lookup_path(tab, host, conn_path) do
     pattern = match_spec_patterns(host, conn_path)
     :ets.select(tab, pattern)
-    |> Enum.sort_by(fn {_, path, _, _, _} -> -length(path) end) # Take the most specific (longest) paths first
+    |> Enum.sort_by(fn {_, path, _, _, _, _} -> -length(path) end) # Take the most specific (longest) paths first
     |> List.first
   end
 
@@ -91,18 +91,18 @@ defmodule Heimdall.DynamicRoutes do
     |> Enum.scan([], &(&2 ++ [&1])) # Enumerates possible path prefixes to match
     |> (fn p -> if length(p) == 0, do: [[]], else: p end).() # Handle if the list is empty
     |> Enum.flat_map(fn prefix -> [ # Generate match specs
-      {{host, prefix, :_, :_, :_}, [], [:"$_"]} # Will only match this prefix
+      {{host, prefix, :_, :_, :_, :_}, [], [:"$_"]} # Will only match this prefix
     ] end)
   end
 
   def call(conn, tab) do
     case lookup_path(tab, conn.host, conn.path_info) do
-      {_, path, plugs, opts, strip_path} ->
+      {_, path, plugs, opts, strip_path, proxy_path} ->
         new_conn  = if strip_path do
           {base, new_path} = Enum.split(conn.path_info, length(path))
-          %{ conn | path_info: new_path, script_name: conn.script_name ++ base }
+          %{ conn | path_info: proxy_path ++ new_path, script_name: conn.script_name ++ base }
         else
-          conn
+          %{ conn | path_info: proxy_path ++ conn.path_info }
         end
         wrap_plugs(plugs, ForwardRequest).(new_conn, opts)
       _ -> 

--- a/lib/marathon/binge_watch.ex
+++ b/lib/marathon/binge_watch.ex
@@ -102,10 +102,12 @@ defmodule Heimdall.Marathon.BingeWatch do
     path = labels |> Map.get("heimdall.path") |> Utils.split
     opts_string = labels |> Map.get("heimdall.options", "{}")
     filters_string = labels |> Map.get("heimdall.filters", "[]")
+    strip_path = labels |> Map.get("heimdall.strip_path", "true") == "true"
+    proxy_path = labels |> Map.get("heimdall.proxy_path", "/") |> Utils.split
     with {:ok, filters} <- Poison.decode(filters_string),
          {:ok, opts} <- Poison.decode(opts_string),
          plugs = Enum.map(filters, &string_to_module/1),
-    do: {host, path, plugs, opts}
+    do: {host, path, plugs, opts, strip_path, proxy_path}
   end
 
   @doc """
@@ -145,8 +147,8 @@ defmodule Heimdall.Marathon.BingeWatch do
 
   def register_routes(routes) do
     DynamicRoutes.unregister_all(:heimdall_routes)
-    Enum.each routes, fn {host, path, plug, opts} ->
-      DynamicRoutes.register(:heimdall_routes, host, path, plug, opts)
+    Enum.each routes, fn route ->
+      DynamicRoutes.register(:heimdall_routes, route)
     end
     routes
   end

--- a/test/dynamic_routes_test.exs
+++ b/test/dynamic_routes_test.exs
@@ -171,7 +171,7 @@ defmodule Heimdall.Test.DynamicRoutes do
   describe "lookup_path" do
     test "gives a route if provided path is the same as the route path", %{tab: tab} do
       path = ["test", "some", "path"]
-      route = {"localhost", path, [], []}
+      route = {"localhost", path, [], [], true}
       DynamicRoutes.register(tab, route)
       result = DynamicRoutes.lookup_path(tab, "localhost", path)
       assert route == result
@@ -180,7 +180,7 @@ defmodule Heimdall.Test.DynamicRoutes do
     test "gives a route if path has additional parts", %{tab: tab} do
       route_path = ["test", "some", "path"]
       longer_path = route_path ++ ["with", "some", "more"]
-      route = {"localhost", route_path, [], []}
+      route = {"localhost", route_path, [], [], true}
       DynamicRoutes.register(tab, route)
       result = DynamicRoutes.lookup_path(tab, "localhost", longer_path)
       assert route == result
@@ -199,7 +199,7 @@ defmodule Heimdall.Test.DynamicRoutes do
       wrong_path = ["test", "some", "path"]
       right_path = ["test", "some", "path", "but", "more", "specific"]
       req_path = right_path ++ ["extra"]
-      expected = {"localhost", right_path, [], []}
+      expected = {"localhost", right_path, [], [], true}
       routes = [
         {"localhost", wrong_path, [], []},
         expected


### PR DESCRIPTION
Added 3 new path features:
* `heimdall.strip_path` - boolean, whether or not the matched `heimdall.path` is removed when forwarding
* `heimdall.proxy_path` - string, a path to be appended to the beginning of the forwarded path
* `heimdall.entrypoints` - string (json list of objects), allows multiple entrypoints to be specified, following the same form as the top level config. Properties left off with be taken from the parent.

An example of `heimdall.entrypoints`:
``` json
{
    ...
    "labels": {
        "heimdall.host": "localhost",
        "heimdall.path": "test",
        "heimdall.entrypoints": "[{\"heimdall.path\": \"another-test\"}]"
    }
    ...
}
```
This would expose two endpoints that get forwarded to the service: `localhost/test` and `localhost/another-test`