### PR TITLE
Add before all filters and global opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Marathon subscriber. Once registered as a callback, Heimdall will start
 listening for change events from Marathon, reloading its dynamic 
 routing config on each change.
 
-Dynamic routing configuration is done through Marathon labels. There are 4 
+Dynamic routing configuration is done through Marathon labels. There are several 
 labels used to decide how a request gets routed for an app:
  * `heimdall.host` (required) - routes a request only if its host matches this value
  * `heimdall.path` (required) - path prefix the request must match (the prefix is stripped from the forwarded request)
  * `heimdall.filters` - a JSON list of plugs through which to filter the request before sending it back off
  * `heimdall.opts` - a JSON object of options that gets passed into each plug
+ * `heimdall.strip_path` - a boolean flag that whether the matched path should be removed when forwarding the request
+ * `heimdall.proxy_path` - a path that is appended to the beginning of the forwarded path
 
 Filters can be viewed as a pipeline of plugs (simple functions that take a 
 request and return a changed request or a response), 
@@ -28,6 +30,10 @@ config. In other words, if `heimdal.filters` is: `["Plugs.First", "Plugs.Second"
  the pipeline would have the following flow:
 
 `Request -> Plugs.First -> Plugs.Second -> Heimdall.Plug.ForwardRequest -> Microservice`
+
+Additionally, if you have a filter that needs to be to run before every request, you can
+add it to the OTP application config `:filter_before_all`, which is a list of plugs that
+run for every request.
 
 Ideally, Heimdall should forward requests to a load balancer that knows how to
 send each request to an actual instance of the microservice it's trying to get

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Additionally, if you have a filter that needs to be to run before every request,
 add it to the OTP application config `:filter_before_all`, which is a list of plugs that
 run for every request. This is useful for things that should happen globally, like caching
 and monitoring.
+Similarly, you can specify a global keyword list of opts to pass into every plug with
+`:global_opts`. These values will be overwritten by the service's `heimdall.opts` config.
 
 Ideally, Heimdall should forward requests to a load balancer that knows how to
 send each request to an actual instance of the microservice it's trying to get

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ config. In other words, if `heimdal.filters` is: `["Plugs.First", "Plugs.Second"
 
 Additionally, if you have a filter that needs to be to run before every request, you can
 add it to the OTP application config `:filter_before_all`, which is a list of plugs that
-run for every request.
+run for every request. This is useful for things that should happen globally, like caching
+and monitoring.
 
 Ideally, Heimdall should forward requests to a load balancer that knows how to
 send each request to an actual instance of the microservice it's trying to get

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,4 +4,5 @@ config :heimdall,
   marathon_url: "http://localhost:8080",
   default_forward_url: "http://localhost/",
   register_marathon: false,
-  port: 4000
+  port: 4000,
+  filter_before_all: []

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,4 +5,5 @@ config :heimdall,
   default_forward_url: "http://localhost/",
   register_marathon: false,
   port: 4000,
-  filter_before_all: []
+  filter_before_all: [],
+  global_opts: []

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,4 +6,4 @@ config :heimdall,
   register_marathon: false,
   port: 4000,
   filter_before_all: [],
-  global_opts: [test_opt: "this is a test option"]
+  global_opts: [test_opt: "this is a test option", overwrite: "this should be overwritten"]

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,4 +5,5 @@ config :heimdall,
   default_forward_url: "http://localhost:8082",
   register_marathon: false,
   port: 4000,
-  filter_before_all: []
+  filter_before_all: [],
+  global_opts: [test_opt: "this is a test option"]

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,5 @@ config :heimdall,
   marathon_url: "http://localhost:8889",
   default_forward_url: "http://localhost:8082",
   register_marathon: false,
-  port: 4000
+  port: 4000,
+  filter_before_all: []

--- a/lib/dynamic_routes.ex
+++ b/lib/dynamic_routes.ex
@@ -114,7 +114,8 @@ defmodule Heimdall.DynamicRoutes do
           %{ conn | path_info: proxy_path ++ conn.path_info }
         end
         filter_before = Application.get_env(:heimdall, :filter_before_all, [])
-        wrap_plugs(filter_before ++ plugs, ForwardRequest).(new_conn, opts)
+        global_opts = Application.get_env(:heimdall, :global_opts, [])
+        wrap_plugs(filter_before ++ plugs, ForwardRequest).(new_conn, Keyword.merge(global_opts, opts))
       _ -> 
         send_resp(conn, 404, "no routes found")
     end

--- a/lib/dynamic_routes.ex
+++ b/lib/dynamic_routes.ex
@@ -95,6 +95,15 @@ defmodule Heimdall.DynamicRoutes do
     ] end)
   end
 
+  @doc """
+  Call is responsible for the majority of the logic in heimdall. 
+
+  It looks up the incoming request using `Heimdall.DynamicRoutes.lookup_path/3`. 
+  If the path matches it either strips the matched path and moves it into the 
+  `script_name` property of the `Conn` or leaves it as be. Finally it wraps all
+  the filter plugs, starting with the plugs in specified in the `:filter_before_all`
+  app config, and ending with the `Heimdall.Plug.ForwardRequest` plug.
+  """
   def call(conn, tab) do
     case lookup_path(tab, conn.host, conn.path_info) do
       {_, path, plugs, opts, strip_path, proxy_path} ->
@@ -104,7 +113,8 @@ defmodule Heimdall.DynamicRoutes do
         else
           %{ conn | path_info: proxy_path ++ conn.path_info }
         end
-        wrap_plugs(plugs, ForwardRequest).(new_conn, opts)
+        filter_before = Application.get_env(:heimdall, :filter_before_all, [])
+        wrap_plugs(filter_before ++ plugs, ForwardRequest).(new_conn, opts)
       _ -> 
         send_resp(conn, 404, "no routes found")
     end

--- a/lib/marathon/binge_watch.ex
+++ b/lib/marathon/binge_watch.ex
@@ -105,8 +105,9 @@ defmodule Heimdall.Marathon.BingeWatch do
     strip_path = app |> Map.get("heimdall.strip_path", "true") == "true"
     proxy_path = app |> Map.get("heimdall.proxy_path", "/") |> Utils.split
     with {:ok, filters} <- Poison.decode(filters_string),
-         {:ok, opts} <- Poison.decode(opts_string),
+         {:ok, opts_map} <- Poison.decode(opts_string),
          plugs = Enum.map(filters, &string_to_module/1),
+         opts = opts_map |> Enum.into([], fn {k, v} -> {String.to_existing_atom(k), v} end),
     do: {host, path, plugs, opts, strip_path, proxy_path}
   end
 

--- a/lib/mix/server.ex
+++ b/lib/mix/server.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Server do
 
   def run(_args) do
     Mix.Task.run "app.start", []
-    unless iex_running?, do: :timer.sleep(:infinity)
+    unless iex_running?(), do: :timer.sleep(:infinity)
   end
 
   def iex_running? do

--- a/test/marathon/binge_watch_test.exs
+++ b/test/marathon/binge_watch_test.exs
@@ -41,7 +41,7 @@ defmodule Heimdall.Test.BingeWatch do
         "localhost",
         ["test"],
         [Heimdall.Test.BingeWatch.TestPlug],
-        %{"forward_url" => "localhost:8080/test"},
+        [forward_url: "localhost:8080/test"],
         true,
         []
       }
@@ -54,7 +54,7 @@ defmodule Heimdall.Test.BingeWatch do
         "heimdall.host" => "localhost",
         "heimdall.path" => "/test",
       }
-      expected = {"localhost", ["test"], [], %{}, true, []}
+      expected = {"localhost", ["test"], [], [], true, []}
       result = BingeWatch.build_route(app)
       assert expected == result
     end


### PR DESCRIPTION
Added global filters that get run before every other plug. This should be useful for things like caching and monitoring.